### PR TITLE
Add visible PDF upload

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,21 @@
 # testecodex
+
+Aplicativo Flask simples para fazer upload de um arquivo PDF, exibir seu
+conteúdo e permitir perguntas sobre o texto.
+
+## Como executar
+
+1. Instale as dependências (pode falhar sem acesso à internet):
+
+```bash
+pip install -r requirements.txt
+```
+
+2. Inicie o servidor:
+
+```bash
+python app.py
+```
+
+3. Acesse `http://localhost:5000` no navegador e envie um PDF para visualizar e
+fazer perguntas.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,89 @@
+import os
+from flask import (
+    Flask,
+    request,
+    render_template,
+    redirect,
+    url_for,
+    send_from_directory,
+)
+from werkzeug.utils import secure_filename
+import pdfplumber
+from transformers import pipeline
+
+app = Flask(__name__)
+
+UPLOAD_FOLDER = "uploads"
+os.makedirs(UPLOAD_FOLDER, exist_ok=True)
+
+# Armazena o texto do PDF carregado
+pdf_text = ""
+pdf_filename = None
+qa_model = None
+
+
+def carregar_modelo():
+    """Carrega o modelo de QA apenas uma vez."""
+    global qa_model
+    if qa_model is None:
+        qa_model = pipeline(
+            "question-answering",
+            model="pierreguillou/bert-base-cased-squad-v1.1-portuguese",
+        )
+
+
+@app.route("/", methods=["GET"])
+def index():
+    url = None
+    if pdf_filename:
+        url = url_for("uploaded_file", filename=pdf_filename)
+    return render_template(
+        "index.html",
+        pdf_carregado=bool(pdf_text),
+        resposta=None,
+        pdf_url=url,
+    )
+
+
+@app.route("/upload", methods=["POST"])
+def upload_pdf():
+    global pdf_text, pdf_filename
+    arquivo = request.files.get("pdf")
+    if not arquivo:
+        return redirect(url_for("index"))
+
+    filename = secure_filename(arquivo.filename)
+    if not filename:
+        filename = "uploaded.pdf"
+    caminho = os.path.join(UPLOAD_FOLDER, filename)
+    arquivo.save(caminho)
+    pdf_filename = filename
+
+    with pdfplumber.open(caminho) as pdf:
+        texto = "\n".join(pagina.extract_text() or "" for pagina in pdf.pages)
+    pdf_text = texto
+    return redirect(url_for("index"))
+
+
+@app.route("/perguntar", methods=["POST"])
+def perguntar():
+    pergunta = request.form.get("pergunta")
+    if not pergunta or not pdf_text:
+        return redirect(url_for("index"))
+
+    carregar_modelo()
+    resposta = qa_model(question=pergunta, context=pdf_text)
+    texto_resposta = resposta.get("answer")
+    return render_template(
+        "index.html", pdf_carregado=True, resposta=texto_resposta
+    )
+
+
+@app.route("/uploads/<path:filename>")
+def uploaded_file(filename):
+    return send_from_directory(UPLOAD_FOLDER, filename)
+
+
+if __name__ == "__main__":
+    port = int(os.environ.get("PORT", 5000))
+    app.run(debug=True, port=port)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+flask
+pdfplumber
+transformers
+torch

--- a/templates/index.html
+++ b/templates/index.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+    <meta charset="UTF-8">
+    <title>Leitor de PDF com Chat</title>
+</head>
+<body>
+    <h1>Leitor de PDF com Chat</h1>
+    <form action="/upload" method="post" enctype="multipart/form-data">
+        <label for="pdf">Selecione o PDF:</label>
+        <input type="file" name="pdf" id="pdf" required>
+        <button type="submit">Enviar PDF</button>
+    </form>
+
+    {% if pdf_carregado %}
+    <hr>
+    {% if pdf_url %}
+    <embed src="{{ pdf_url }}" type="application/pdf" width="100%" height="600px" />
+    {% endif %}
+    <form action="/perguntar" method="post">
+        <label for="pergunta">Pergunta:</label>
+        <input type="text" name="pergunta" id="pergunta" required>
+        <button type="submit">Enviar</button>
+    </form>
+
+    {% if resposta %}
+    <p><strong>Resposta:</strong> {{ resposta }}</p>
+    {% endif %}
+    {% endif %}
+</body>
+</html>


### PR DESCRIPTION
## Summary
- serve uploaded PDFs from `uploads/` directory
- show uploaded PDF on the page after upload
- document running the app in README

## Testing
- `python -m py_compile app.py`
- `pip install -r requirements.txt` *(fails: Tunnel connection failed)*

------
https://chatgpt.com/codex/tasks/task_e_6856171907448324ab8c73a1310e179e